### PR TITLE
docs: include link to GH pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # desmos-docs-unofficial
  Unofficial documentation for all the obscure features of Desmos Graphing Calculator. Not endorsed or sponsored by Desmos!
 
+ Currently hosted on [GitHub Pages](https://radian628.github.io/desmos-docs-unofficial/).
+
 ## Contributing
  Add anything to this that would be valuable as a public resource for other Desmos users/artists/creators/programmers/et cetera. This can be core Desmos features, clever uses of Desmos features, good practices, and a whole lot of other stuff. Formatting and standards for this site in general are still pending.


### PR DESCRIPTION
Just a small PR to add a link to where the site is currently hosted so people can find it a bit easier.